### PR TITLE
Fix scope source

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ All the following options are sent to [has_user_access?/4](https://hexdocs.pm/ra
 
 * `:scope`
   - `false`: disables scoping
-  - `User`: a module that will be passed to `c:Rajska.Authorization.has_user_access?/4`. It must implement a `Rajska.Authorization` behaviour and a `__schema__(:source)` function (used to check if the module is valid in `Rajska.Schema.validate_query_auth_config!/2`)
+  - `User`: a module that will be passed to `c:Rajska.Authorization.has_user_access?/4`. It must define a struct.
 * `:args`
   - `%{user_id: [:params, :id]}`: where `user_id` is the scoped field and `id` is an argument nested inside the `params` argument.
   - `:id`: this is the same as `%{id: :id}`, where `:id` is both the query argument and the scoped field that will be passed to [has_user_access?/4](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/4)

--- a/lib/middlewares/query_scope_authorization.ex
+++ b/lib/middlewares/query_scope_authorization.ex
@@ -96,8 +96,6 @@ defmodule Rajska.QueryScopeAuthorization do
     raise "Error in query #{name}: no scope argument found in middleware Scope Authorization"
   end
 
-  defp get_arguments_source!(%Resolution{source: source}, :source), do: source
-
   defp get_arguments_source!(%Resolution{arguments: args}, _scope), do: args
 
   def apply_scope_authorization(

--- a/lib/middlewares/query_scope_authorization.ex
+++ b/lib/middlewares/query_scope_authorization.ex
@@ -47,7 +47,7 @@ defmodule Rajska.QueryScopeAuthorization do
 
     * `:scope`
       - `false`: disables scoping
-      - `User`: a module that will be passed to `c:Rajska.Authorization.has_user_access?/4`. It must implement a `Rajska.Authorization` behaviour and a `__schema__(:source)` function (used to check if the module is valid in `Rajska.Schema.validate_query_auth_config!/2`)
+      - `User`: a module that will be passed to `c:Rajska.Authorization.has_user_access?/4`. It must define a struct.
     * `:args`
       - `%{user_id: [:params, :id]}`: where `user_id` is the scoped field and `id` is an argument nested inside the `params` argument.
       - `:id`: this is the same as `%{id: :id}`, where `:id` is both the query argument and the scoped field that will be passed to `c:Rajska.Authorization.has_user_access?/4`

--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -98,9 +98,9 @@ defmodule Rajska.Schema do
   defp validate_scope!(false, _role, _authorization), do: :ok
 
   defp validate_scope!(scope, _role, _authorization) when is_atom(scope) do
-    scope.__schema__(:source)
+    struct!(scope)
   rescue
-    UndefinedFunctionError -> reraise ":scope option #{inspect(scope)} doesn't implement a __schema__(:source) function.", __STACKTRACE__
+    UndefinedFunctionError -> reraise ":scope option #{inspect(scope)} is not a struct.", __STACKTRACE__
   end
 
   defp validate_args!(args) when is_map(args) do

--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -53,7 +53,7 @@ defmodule Rajska.Schema do
   @spec validate_query_auth_config!(
     [
       permit: atom(),
-      scope: false | :source | module(),
+      scope: false | module(),
       args: %{} | [] | atom(),
       optional: false | true,
       rule: atom()
@@ -96,8 +96,6 @@ defmodule Rajska.Schema do
   end
 
   defp validate_scope!(false, _role, _authorization), do: :ok
-
-  defp validate_scope!(:source,  _role, _authorization), do: :ok
 
   defp validate_scope!(scope, _role, _authorization) when is_atom(scope) do
     scope.__schema__(:source)

--- a/test/middlewares/object_scope_authorization_test.exs
+++ b/test/middlewares/object_scope_authorization_test.exs
@@ -138,6 +138,12 @@ defmodule Rajska.ObjectScopeAuthorizationTest do
           {:ok, %User{id: 1}}
         end
       end
+
+      field :string_query, :string do
+        resolve fn _args, _ ->
+          {:ok, "STRING"}
+        end
+      end
     end
 
     object :user do
@@ -311,6 +317,12 @@ defmodule Rajska.ObjectScopeAuthorizationTest do
     ] == errors
   end
 
+  test "ignores object when is a primitive" do
+    assert {:ok, result} = run_pipeline(string_query(), context(:user, 1))
+    assert %{data: %{"stringQuery" => "STRING"}} = result
+    refute Map.has_key?(result, :errors)
+  end
+
   test "Raises when no meta scope_by is defined for an object" do
     assert_raise RuntimeError, ~r/No meta scope_by defined for object :not_scoped/, fn ->
       assert {:ok, _result} = run_pipeline(object_not_scoped_query(2), context(:user, 2))
@@ -454,6 +466,14 @@ defmodule Rajska.ObjectScopeAuthorizationTest do
       userQueryWithRule {
         id
       }
+    }
+    """
+  end
+
+  defp string_query do
+    """
+    {
+      stringQuery
     }
     """
   end

--- a/test/middlewares/object_scope_authorization_test.exs
+++ b/test/middlewares/object_scope_authorization_test.exs
@@ -6,8 +6,6 @@ defmodule Rajska.ObjectScopeAuthorizationTest do
       id: 1,
       total: 10,
     ]
-
-    def __schema__(:source), do: "wallets"
   end
 
   defmodule Company do
@@ -17,8 +15,6 @@ defmodule Rajska.ObjectScopeAuthorizationTest do
       user_id: 1,
       wallet: %Wallet{}
     ]
-
-    def __schema__(:source), do: "companies"
   end
 
   defmodule User do
@@ -30,16 +26,12 @@ defmodule Rajska.ObjectScopeAuthorizationTest do
       companies: [],
       not_scoped: nil,
     ]
-
-    def __schema__(:source), do: "users"
   end
 
   defmodule NotScoped do
     defstruct [
       id: 1,
     ]
-
-    def __schema__(:source), do: "not_scopeds"
   end
 
   defmodule Authorization do

--- a/test/middlewares/object_scope_authorization_test.exs
+++ b/test/middlewares/object_scope_authorization_test.exs
@@ -42,7 +42,7 @@ defmodule Rajska.ObjectScopeAuthorizationTest do
     def has_user_access?(%{role: :admin}, User, _field, :default), do: true
     def has_user_access?(%{id: user_id}, User, {:id, id}, :default) when user_id === id, do: true
     def has_user_access?(_current_user, User, _field, :default), do: false
-    def has_user_access?(_crreutn_user, User, _field, :object), do: false
+    def has_user_access?(_current_user, User, _field, :object), do: false
 
     def has_user_access?(%{role: :admin}, Company, _field, :default), do: true
     def has_user_access?(%{id: user_id}, Company, {:user_id, company_user_id}, :default) when user_id === company_user_id, do: true

--- a/test/middlewares/query_scope_authorization_test.exs
+++ b/test/middlewares/query_scope_authorization_test.exs
@@ -7,8 +7,6 @@ defmodule Rajska.QueryScopeAuthorizationTest do
       name: "User",
       email: "email@user.com"
     ]
-
-    def __schema__(:source), do: "users"
   end
 
   defmodule BankAccount do
@@ -16,8 +14,6 @@ defmodule Rajska.QueryScopeAuthorizationTest do
       id: 1,
       total: 5,
     ]
-
-    def __schema__(:source), do: "bank_account"
   end
 
   defmodule Authorization do

--- a/test/middlewares/schema_test.exs
+++ b/test/middlewares/schema_test.exs
@@ -13,8 +13,10 @@ defmodule Rajska.SchemaTest do
       name: "User",
       email: "email@user.com"
     ]
+  end
 
-    def __schema__(:source), do: "users"
+  defmodule NotStruct do
+    def hello, do: :world
   end
 
   test "Raises if no permission is specified for a query" do
@@ -115,10 +117,10 @@ defmodule Rajska.SchemaTest do
     end
   end
 
-  test "Raises if scope module doesn't implement a __schema__(:source) function" do
+  test "Raises if scope module is not a struct" do
     assert_raise(
       RuntimeError,
-      ~r/Query get_user is configured incorrectly, :scope option :invalid_module doesn't implement a __schema__/,
+      ~r/Query get_user is configured incorrectly, :scope option Rajska.SchemaTest.NotStruct is not a struct/,
       fn ->
         defmodule SchemaNoStruct do
           use Absinthe.Schema
@@ -134,7 +136,7 @@ defmodule Rajska.SchemaTest do
 
           query do
             field :get_user, :string do
-              middleware Rajska.QueryAuthorization, [permit: :user, scope: :invalid_module]
+              middleware Rajska.QueryAuthorization, [permit: :user, scope: NotStruct]
               resolve fn _args, _info -> {:ok, "bob"} end
             end
           end

--- a/test/middlewares/schema_test.exs
+++ b/test/middlewares/schema_test.exs
@@ -7,6 +7,16 @@ defmodule Rajska.SchemaTest do
       super_role: :admin
   end
 
+  defmodule User do
+    defstruct [
+      id: 1,
+      name: "User",
+      email: "email@user.com"
+    ]
+
+    def __schema__(:source), do: "users"
+  end
+
   test "Raises if no permission is specified for a query" do
     assert_raise RuntimeError, ~r/No permission specified for query get_user/, fn ->
       defmodule Schema do
@@ -152,7 +162,7 @@ defmodule Rajska.SchemaTest do
 
           query do
             field :get_user, :string do
-              middleware Rajska.QueryAuthorization, [permit: :user, scope: :source, args: "args"]
+              middleware Rajska.QueryAuthorization, [permit: :user, scope: User, args: "args"]
               resolve fn _args, _info -> {:ok, "bob"} end
             end
           end
@@ -180,7 +190,7 @@ defmodule Rajska.SchemaTest do
 
           query do
             field :get_user, :string do
-              middleware Rajska.QueryAuthorization, [permit: :user, scope: :source, optional: :invalid]
+              middleware Rajska.QueryAuthorization, [permit: :user, scope: User, optional: :invalid]
               resolve fn _args, _info -> {:ok, "bob"} end
             end
           end
@@ -208,7 +218,7 @@ defmodule Rajska.SchemaTest do
 
           query do
             field :get_user, :string do
-              middleware Rajska.QueryAuthorization, [permit: :user, scope: :source, rule: 4]
+              middleware Rajska.QueryAuthorization, [permit: :user, scope: User, rule: 4]
               resolve fn _args, _info -> {:ok, "bob"} end
             end
           end

--- a/test/middlewares/schema_test.exs
+++ b/test/middlewares/schema_test.exs
@@ -19,7 +19,7 @@ defmodule Rajska.SchemaTest do
 
   test "Raises if no permission is specified for a query" do
     assert_raise RuntimeError, ~r/No permission specified for query get_user/, fn ->
-      defmodule Schema do
+      defmodule SchemaNoPermission do
         use Absinthe.Schema
 
         def context(ctx), do: Map.put(ctx, :authorization, Authorization)
@@ -45,7 +45,7 @@ defmodule Rajska.SchemaTest do
       RuntimeError,
       ~r/Query get_user is configured incorrectly, :scope option must be present for role :user/,
       fn ->
-        defmodule Schema do
+        defmodule SchemaNoScope do
           use Absinthe.Schema
 
           def context(ctx), do: Map.put(ctx, :authorization, Authorization)
@@ -73,7 +73,7 @@ defmodule Rajska.SchemaTest do
       RuntimeError,
       ~r/Error in query getUser: no scope argument found in middleware Scope Authorization/,
       fn ->
-        defmodule Schema do
+        defmodule SchemaNoScopeRuntime do
           use Absinthe.Schema
 
           def context(ctx), do: Map.put(ctx, :authorization, Authorization)
@@ -86,14 +86,14 @@ defmodule Rajska.SchemaTest do
           end
         end
 
-        {:ok, _result} = Absinthe.run("{ getUser }", Schema, context: %{current_user: %{role: :user}})
+        {:ok, _result} = Absinthe.run("{ getUser }", SchemaNoScopeRuntime, context: %{current_user: %{role: :user}})
       end
     )
   end
 
   test "Raises if no permit key is specified for a query" do
     assert_raise RuntimeError, ~r/Query get_user is configured incorrectly, :permit option must be present/, fn ->
-      defmodule Schema do
+      defmodule SchemaNoPermit do
         use Absinthe.Schema
 
         def context(ctx), do: Map.put(ctx, :authorization, Authorization)
@@ -120,7 +120,7 @@ defmodule Rajska.SchemaTest do
       RuntimeError,
       ~r/Query get_user is configured incorrectly, :scope option :invalid_module doesn't implement a __schema__/,
       fn ->
-        defmodule Schema do
+        defmodule SchemaNoStruct do
           use Absinthe.Schema
 
           def context(ctx), do: Map.put(ctx, :authorization, Authorization)
@@ -148,7 +148,7 @@ defmodule Rajska.SchemaTest do
       RuntimeError,
       ~r/Query get_user is configured incorrectly, the following args option is invalid: "args"/,
       fn ->
-        defmodule Schema do
+        defmodule SchemaInvalidArgs do
           use Absinthe.Schema
 
           def context(ctx), do: Map.put(ctx, :authorization, Authorization)
@@ -176,7 +176,7 @@ defmodule Rajska.SchemaTest do
       RuntimeError,
       ~r/Query get_user is configured incorrectly, :optional option must be a boolean./,
       fn ->
-        defmodule Schema do
+        defmodule SchemaInvalidOptional do
           use Absinthe.Schema
 
           def context(ctx), do: Map.put(ctx, :authorization, Authorization)
@@ -204,7 +204,7 @@ defmodule Rajska.SchemaTest do
       RuntimeError,
       ~r/Query get_user is configured incorrectly, :rule option must be an atom./,
       fn ->
-        defmodule Schema do
+        defmodule SchemaInvalidRule do
           use Absinthe.Schema
 
           def context(ctx), do: Map.put(ctx, :authorization, Authorization)


### PR DESCRIPTION
- [x] Remove `scope: :source`
- [x] Change `scope` to `scope_by` in ObjectScopeAuthorization, using the returned struct as scope
- [x] Change validations to require any struct instead of an Ecto schema
- [ ] Add `meta :rule` for FieldAuthorization
- [ ] Use source struct and `scope_by` for FieldAuthorization scoping
- [x] Add `meta :rule` for ObjectScopeAuthorization
- [ ] Unify all scope functions in Rajska (no more `context_field_authorized`)
- [x] Test queries that return primitives (e.g. `:string`)
