### PR TITLE
Merge has_user_access?/4 args and pass entire object to has_user_access?/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ end
 
 ### Field Authorization
 
-Authorizes Absinthe's object [field](https://hexdocs.pm/absinthe/Absinthe.Schema.Notation.html#field/4) according to the result of the [has_user_access?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/3) function, which receives the user role, the `source` object that is resolving the field and the object rule.
+Authorizes Absinthe's object [field](https://hexdocs.pm/absinthe/Absinthe.Schema.Notation.html#field/4) according to the result of the [has_user_access?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/3) function, which receives the user role, the `source` object that is resolving the field and the field rule.
 
 Usage:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ end
 
 ## Usage
 
-Create your Authorization module, which will implement the [Rajska Authorization](https://hexdocs.pm/rajska/Rajska.Authorization.html) behaviour and contain the logic to validate user permissions and will be called by Rajska middlewares. Rajska provides some helper functions by default, such as [role_authorized?/2](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:role_authorized?/2), [has_user_access?/4](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/4) and [field_authorized?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:field_authorized?/3), but you can override them with your application needs.
+Create your Authorization module, which will implement the [Rajska Authorization](https://hexdocs.pm/rajska/Rajska.Authorization.html) behaviour and contain the logic to validate user permissions and will be called by Rajska middlewares. Rajska provides some helper functions by default, such as [role_authorized?/2](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:role_authorized?/2), [has_user_access?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/3) and [field_authorized?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:field_authorized?/3), but you can override them with your application needs.
 
 ```elixir
   defmodule Authorization do
@@ -127,14 +127,14 @@ In the above example, `:all` and `:admin` (`super_role`) permissions don't requi
 
 ## Options
 
-All the following options are sent to [has_user_access?/4](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/4):
+All the following options are sent to [has_user_access?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/3):
 
 * `:scope`
   - `false`: disables scoping
-  - `User`: a module that will be passed to `c:Rajska.Authorization.has_user_access?/4`. It must define a struct.
+  - `User`: a module that will be passed to `c:Rajska.Authorization.has_user_access?/3`. It must define a struct.
 * `:args`
   - `%{user_id: [:params, :id]}`: where `user_id` is the scoped field and `id` is an argument nested inside the `params` argument.
-  - `:id`: this is the same as `%{id: :id}`, where `:id` is both the query argument and the scoped field that will be passed to [has_user_access?/4](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/4)
+  - `:id`: this is the same as `%{id: :id}`, where `:id` is both the query argument and the scoped field that will be passed to [has_user_access?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/3)
   - `[:code, :user_group_id]`: this is the same as `%{code: :code, user_group_id: :user_group_id}`, where `code` and `user_group_id` are both query arguments and scoped fields.
 * `:optional` (optional) - when set to true the arguments are optional, so if no argument is provided, the query will be authorized. Defaults to false.
 * `:rule` (optional) - allows the same struct to have different rules. See `Rajska.Authorization` for `rule` default settings.
@@ -225,7 +225,7 @@ object :wallet do
 end
 ```
 
-To define custom rules for the scoping, use [has_user_access?/4](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/4). For example:
+To define custom rules for the scoping, use [has_user_access?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/3). For example:
 
 ```elixir
 defmodule Authorization do
@@ -234,13 +234,13 @@ defmodule Authorization do
     super_role: :admin
 
   @impl true
-  def has_user_access?(%{role: :admin}, User, _field, _rule), do: true
-  def has_user_access?(%{id: user_id}, User, {:id, id}, _rule) when user_id === id, do: true
-  def has_user_access?(_current_user, User, _field, _rule), do: false
+  def has_user_access?(%{role: :admin}, %User{}, _rule), do: true
+  def has_user_access?(%{id: user_id}, %User{id: id}, _rule) when user_id === id, do: true
+  def has_user_access?(_current_user, %User{}, _rule), do: false
 end
 ```
 
-Keep in mind that the `field_value` provided to `has_user_access?/4` can be `nil`. This case can be handled as you wish.
+Keep in mind that the `field_value` provided to `has_user_access?/3` can be `nil`. This case can be handled as you wish.
 For example, to not raise any authorization errors and just return `nil`:
 
 ```elixir
@@ -250,11 +250,9 @@ defmodule Authorization do
     super_role: :admin
 
   @impl true
-  def has_user_access?(_user, _scope, {_field, nil}, _rule), do: true
-
-  def has_user_access?(%{role: :admin}, User, _field, _rule), do: true
-  def has_user_access?(%{id: user_id}, User, {:id, id}, _rule) when user_id === id, do: true
-  def has_user_access?(_current_user, User, _field, _rule), do: false
+  def has_user_access?(%{role: :admin}, %User{}, _rule), do: true
+  def has_user_access?(%{id: user_id}, %User{id: id}, _rule) when user_id === id, do: true
+  def has_user_access?(_current_user, %User{}, _rule), do: false
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ end
 
 ## Usage
 
-Create your Authorization module, which will implement the [Rajska Authorization](https://hexdocs.pm/rajska/Rajska.Authorization.html) behaviour and contain the logic to validate user permissions and will be called by Rajska middlewares. Rajska provides some helper functions by default, such as [role_authorized?/2](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:role_authorized?/2), [has_user_access?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/3) and [field_authorized?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:field_authorized?/3), but you can override them with your application needs.
+Create your Authorization module, which will implement the [Rajska Authorization](https://hexdocs.pm/rajska/Rajska.Authorization.html) behaviour and contain the logic to validate user permissions and will be called by Rajska middlewares. Rajska provides some helper functions by default, such as [role_authorized?/2](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:role_authorized?/2) and [has_user_access?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/3), but you can override them with your application needs.
 
 ```elixir
   defmodule Authorization do
@@ -258,16 +258,14 @@ end
 
 ### Field Authorization
 
-Authorizes Absinthe's object [field](https://hexdocs.pm/absinthe/Absinthe.Schema.Notation.html#field/4) according to the result of the [field_authorized?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:field_authorized?/3) function, which receives the user role, the meta `scope_by` atom defined in the object schema and the `source` object that is resolving the field.
+Authorizes Absinthe's object [field](https://hexdocs.pm/absinthe/Absinthe.Schema.Notation.html#field/4) according to the result of the [has_user_access?/3](https://hexdocs.pm/rajska/Rajska.Authorization.html#c:has_user_access?/3) function, which receives the user role, the `source` object that is resolving the field and the object rule.
 
 Usage:
 
-[Create your Authorization module and add it and FieldAuthorization to your Absinthe.Schema](#usage). Then add the meta `scope_by` to an object and meta `private` to your sensitive fields:
+[Create your Authorization module and add it and FieldAuthorization to your Absinthe.Schema](#usage).
 
 ```elixir
   object :user do
-    meta :scope_by, :id
-
     field :name, :string
     field :is_email_public, :boolean
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `rajska` to your list of dependencies in 
 ```elixir
 def deps do
   [
-    {:rajska, "~> 0.8.1"},
+    {:rajska, "~> 0.9.0"},
   ]
 end
 ```

--- a/lib/authorization.ex
+++ b/lib/authorization.ex
@@ -21,8 +21,7 @@ defmodule Rajska.Authorization do
 
   @callback has_user_access?(
     current_user,
-    scope :: module(),
-    {field :: any(), field_value :: any()},
+    scoped_struct :: struct(),
     rule :: any()
   ) :: boolean()
 
@@ -33,6 +32,6 @@ defmodule Rajska.Authorization do
                       not_scoped_roles: 0,
                       role_authorized?: 2,
                       field_authorized?: 3,
-                      has_user_access?: 4,
+                      has_user_access?: 3,
                       unauthorized_msg: 1
 end

--- a/lib/authorization.ex
+++ b/lib/authorization.ex
@@ -17,13 +17,7 @@ defmodule Rajska.Authorization do
 
   @callback role_authorized?(current_user_role, allowed_role :: role) :: boolean()
 
-  @callback field_authorized?(current_user_role, scope_by :: atom(), source :: map()) :: boolean()
-
-  @callback has_user_access?(
-    current_user,
-    scoped_struct :: struct(),
-    rule :: any()
-  ) :: boolean()
+  @callback has_user_access?(current_user, scoped_struct :: struct(), rule :: any()) :: boolean()
 
   @callback unauthorized_msg(resolution :: Resolution.t()) :: String.t()
 
@@ -31,7 +25,6 @@ defmodule Rajska.Authorization do
                       get_user_role: 1,
                       not_scoped_roles: 0,
                       role_authorized?: 2,
-                      field_authorized?: 3,
                       has_user_access?: 3,
                       unauthorized_msg: 1
 end

--- a/lib/authorization.ex
+++ b/lib/authorization.ex
@@ -8,8 +8,11 @@ defmodule Rajska.Authorization do
   @type current_user :: any()
   @type role :: atom()
   @type current_user_role :: role
+  @type context :: map()
+  @type scoped_struct :: struct()
+  @type rule :: atom()
 
-  @callback get_current_user(context :: map()) :: current_user
+  @callback get_current_user(context) :: current_user
 
   @callback get_user_role(current_user) :: role
 
@@ -17,14 +20,20 @@ defmodule Rajska.Authorization do
 
   @callback role_authorized?(current_user_role, allowed_role :: role) :: boolean()
 
-  @callback has_user_access?(current_user, scoped_struct :: struct(), rule :: any()) :: boolean()
+  @callback has_user_access?(current_user, scoped_struct, rule) :: boolean()
 
   @callback unauthorized_message(resolution :: Resolution.t()) :: String.t()
+
+  @callback context_role_authorized?(context, allowed_role :: role) :: boolean()
+
+  @callback context_user_authorized?(context, scoped_struct, rule) :: boolean()
 
   @optional_callbacks get_current_user: 1,
                       get_user_role: 1,
                       not_scoped_roles: 0,
                       role_authorized?: 2,
                       has_user_access?: 3,
-                      unauthorized_message: 1
+                      unauthorized_message: 1,
+                      context_role_authorized?: 2,
+                      context_user_authorized?: 3
 end

--- a/lib/authorization.ex
+++ b/lib/authorization.ex
@@ -19,12 +19,12 @@ defmodule Rajska.Authorization do
 
   @callback has_user_access?(current_user, scoped_struct :: struct(), rule :: any()) :: boolean()
 
-  @callback unauthorized_msg(resolution :: Resolution.t()) :: String.t()
+  @callback unauthorized_message(resolution :: Resolution.t()) :: String.t()
 
   @optional_callbacks get_current_user: 1,
                       get_user_role: 1,
                       not_scoped_roles: 0,
                       role_authorized?: 2,
                       has_user_access?: 3,
-                      unauthorized_msg: 1
+                      unauthorized_message: 1
 end

--- a/lib/middlewares/field_authorization.ex
+++ b/lib/middlewares/field_authorization.ex
@@ -2,16 +2,14 @@ defmodule Rajska.FieldAuthorization do
   @moduledoc """
   Absinthe middleware to ensure field permissions.
 
-  Authorizes Absinthe's object [field](https://hexdocs.pm/absinthe/Absinthe.Schema.Notation.html#field/4) according to the result of the `c:Rajska.Authorization.field_authorized?/3` function, which receives the user role, the meta `scope_by` atom defined in the object schema and the `source` object that is resolving the field.
+  Authorizes Absinthe's object [field](https://hexdocs.pm/absinthe/Absinthe.Schema.Notation.html#field/4) according to the result of the `c:Rajska.Authorization.has_user_access?/3` function, which receives the user role, the `source` object that is resolving the field and the object rule.
 
   ## Usage
 
-  [Create your Authorization module and add it and FieldAuthorization to your Absinthe.Schema](https://hexdocs.pm/rajska/Rajska.html#module-usage). Then add the meta `scope_by` to an object and meta `private` to your sensitive fields:
+  [Create your Authorization module and add it and FieldAuthorization to your Absinthe.Schema](https://hexdocs.pm/rajska/Rajska.html#module-usage).
 
   ```elixir
   object :user do
-    meta :scope_by, :id
-
     field :name, :string
     field :is_email_public, :boolean
 

--- a/lib/middlewares/field_authorization.ex
+++ b/lib/middlewares/field_authorization.ex
@@ -2,7 +2,7 @@ defmodule Rajska.FieldAuthorization do
   @moduledoc """
   Absinthe middleware to ensure field permissions.
 
-  Authorizes Absinthe's object [field](https://hexdocs.pm/absinthe/Absinthe.Schema.Notation.html#field/4) according to the result of the `c:Rajska.Authorization.has_user_access?/3` function, which receives the user role, the `source` object that is resolving the field and the object rule.
+  Authorizes Absinthe's object [field](https://hexdocs.pm/absinthe/Absinthe.Schema.Notation.html#field/4) according to the result of the `c:Rajska.Authorization.has_user_access?/3` function, which receives the user role, the `source` object that is resolving the field and the field rule.
 
   ## Usage
 

--- a/lib/middlewares/field_authorization.ex
+++ b/lib/middlewares/field_authorization.ex
@@ -32,14 +32,14 @@ defmodule Rajska.FieldAuthorization do
 
   def call(resolution, [object: %Type.Object{fields: fields} = object, field: field]) do
     field_private? = fields[field] |> Type.meta(:private) |> field_private?(resolution.source)
-    scope_by = get_scope_by_field!(object, field_private?)
+    scope? = get_scope!(object)
 
     default_rule = Rajska.apply_auth_mod(resolution.context, :default_rule)
     rule = Type.meta(fields[field], :rule) || default_rule
 
     resolution
     |> Map.get(:context)
-    |> authorized?(field_private?, scope_by, resolution, rule)
+    |> authorized?(scope? && field_private?, resolution.source, rule)
     |> put_result(resolution, field)
   end
 
@@ -47,30 +47,22 @@ defmodule Rajska.FieldAuthorization do
   defp field_private?(private, source) when is_function(private), do: private.(source)
   defp field_private?(_private, _source), do: false
 
-  defp get_scope_by_field!(_object, false), do: :ok
+  defp get_scope!(object) do
+    scope? = Type.meta(object, :scope?)
+    scope_field? = Type.meta(object, :scope_field?)
 
-  defp get_scope_by_field!(object, _private) do
-    general_scope_by = Type.meta(object, :scope_by)
-    field_scope_by = Type.meta(object, :scope_field_by)
-
-    case {general_scope_by, field_scope_by} do
-      {nil, nil} -> raise "No meta scope_by or scope_field_by defined for object #{inspect object.identifier}"
-      {nil, field_scope_by} -> field_scope_by
-      {general_scope_by, nil} -> general_scope_by
-      {_, _} -> raise "Error in #{inspect object.identifier}. If scope_field_by is defined, then scope_by must not be defined"
+    case {scope?, scope_field?} do
+      {nil, nil} -> true
+      {nil, scope_field?} -> scope_field?
+      {scope?, nil} -> scope?
+      {_, _} -> raise "Error in #{inspect object.identifier}. If scope_field? is defined, then scope? must not be defined"
     end
   end
 
-  defp authorized?(_context, false, _scope_by, _source, _rule), do: true
+  defp authorized?(_context, false, _source, _rule), do: true
 
-  defp authorized?(context, true, scope_by, %{source: %scope{} = source}, rule) do
-    field_value = Map.get(source, scope_by)
-
-    Rajska.apply_auth_mod(context, :has_context_access?, [context, scope, {scope_by, field_value}, rule])
-  end
-
-  defp authorized?(_context, true, _scope_by, %{source: source, definition: definition}, _rule) do
-    raise "Expected a Struct for source object in field #{inspect(definition.name)}, got #{inspect(source)}"
+  defp authorized?(context, true, source, rule) do
+    Rajska.apply_auth_mod(context, :context_user_authorized?, [context, source, rule])
   end
 
   defp put_result(true, resolution, _field), do: resolution

--- a/lib/middlewares/object_authorization.ex
+++ b/lib/middlewares/object_authorization.ex
@@ -94,7 +94,7 @@ defmodule Rajska.ObjectAuthorization do
   defp authorized?(nil, _, object), do: raise "No meta authorize defined for object #{inspect object.identifier}"
 
   defp authorized?(permission, context, _object) do
-    Rajska.apply_auth_mod(context, :context_authorized?, [context, permission])
+    Rajska.apply_auth_mod(context, :context_role_authorized?, [context, permission])
   end
 
   defp put_result(true, fields, resolution, _type), do: find_associations(fields, resolution)

--- a/lib/middlewares/object_scope_authorization.ex
+++ b/lib/middlewares/object_scope_authorization.ex
@@ -120,7 +120,7 @@ defmodule Rajska.ObjectScopeAuthorization do
     default_rule = Rajska.apply_auth_mod(context, :default_rule)
     rule = Type.meta(type, :rule) || default_rule
 
-    case !scope? || authorized?(context, root_value, rule) do
+    case authorized?(scope?, context, root_value, rule) do
       true -> %{result | fields: walk_result(fields, context)}
       false -> Map.put(result, :errors, [error(emitter)])
     end
@@ -155,7 +155,9 @@ defmodule Rajska.ObjectScopeAuthorization do
     end
   end
 
-  defp authorized?(context, scoped_struct, rule) do
+  defp authorized?(false, _context, _scoped_struct, _rule), do: true
+
+  defp authorized?(true, context, scoped_struct, rule) do
     Rajska.apply_auth_mod(context, :context_user_authorized?, [context, scoped_struct, rule])
   end
 

--- a/lib/middlewares/object_scope_authorization.ex
+++ b/lib/middlewares/object_scope_authorization.ex
@@ -156,7 +156,7 @@ defmodule Rajska.ObjectScopeAuthorization do
   end
 
   defp authorized?(context, scoped_struct, rule) do
-    Rajska.apply_auth_mod(context, :has_user_access?, [context.current_user, scoped_struct, rule])
+    Rajska.apply_auth_mod(context, :context_user_authorized?, [context, scoped_struct, rule])
   end
 
   defp error(%{source_location: location, schema_node: %{type: type}}) do

--- a/lib/middlewares/object_scope_authorization.ex
+++ b/lib/middlewares/object_scope_authorization.ex
@@ -39,7 +39,7 @@ defmodule Rajska.ObjectScopeAuthorization do
   end
   ```
 
-  To define custom rules for the scoping, use `c:Rajska.Authorization.has_user_access?/4`. For example:
+  To define custom rules for the scoping, use `c:Rajska.Authorization.has_user_access?/3`. For example:
 
   ```elixir
   defmodule Authorization do
@@ -47,13 +47,13 @@ defmodule Rajska.ObjectScopeAuthorization do
       valid_roles: [:user, :admin]
 
     @impl true
-    def has_user_access?(%{role: :admin}, _struct, {_field, _field_value}, _rule), do: true
-    def has_user_access?(%{id: user_id}, User, {:id, id}, _rule) when user_id === id, do: true
-    def has_user_access?(_current_user, User, {_field, _field_value}, _rule), do: false
+    def has_user_access?(%{role: :admin}, _, _scoped_struct, _rule), do: true
+    def has_user_access?(%{id: user_id}, %User{id: id}, _rule) when user_id === id, do: true
+    def has_user_access?(_current_user, %User{}, _rule), do: false
   end
   ```
 
-  Keep in mind that the `field_value` provided to `has_user_access?/4` can be `nil`. This case can be handled as you wish.
+  Keep in mind that the `field_value` provided to `has_user_access?/3` can be `nil`. This case can be handled as you wish.
   For example, to not raise any authorization errors and just return `nil`:
 
   ```elixir
@@ -62,15 +62,13 @@ defmodule Rajska.ObjectScopeAuthorization do
       valid_roles: [:user, :admin]
 
     @impl true
-    def has_user_access?(_user, _scope, {_field, nil}, _rule), do: true
-
-    def has_user_access?(%{role: :admin}, User, {_field, _field_value}, _rule), do: true
-    def has_user_access?(%{id: user_id}, User, {:id, id}, _rule) when user_id === id, do: true
-    def has_user_access?(_current_user, User, {_field, _field_value}, _rule), do: false
+    def has_user_access?(%User{role: :admin}, _scoped_struct, _rule), do: true
+    def has_user_access?(%User{id: user_id}, %User{id: id}, _rule) when user_id === id, do: true
+    def has_user_access?(_current_user, %User{}, _rule), do: false
   end
   ```
 
-  The `rule` keyword is not mandatory and will be pattern matched in `has_user_access?/4`:
+  The `rule` keyword is not mandatory and will be pattern matched in `has_user_access?/3`:
 
   ```elixir
   defmodule Authorization do
@@ -78,8 +76,8 @@ defmodule Rajska.ObjectScopeAuthorization do
       valid_roles: [:user, :admin]
 
     @impl true
-    def has_user_access?(%{id: user_id}, Wallet, {_field, _field_value}, :read_only), do: true
-    def has_user_access?(%{id: user_id}, Wallet, {_field, _field_value}, :default), do: false
+    def has_user_access?(%{id: user_id}, %Wallet{}, :read_only), do: true
+    def has_user_access?(%{id: user_id}, %Wallet{}, :default), do: false
   end
   ```
 

--- a/lib/middlewares/query_authorization.ex
+++ b/lib/middlewares/query_authorization.ex
@@ -71,6 +71,6 @@ defmodule Rajska.QueryAuthorization do
   defp update_result(true, resolution), do: resolution
 
   defp update_result(false, %{context: context} = resolution) do
-    Resolution.put_result(resolution, {:error, Rajska.apply_auth_mod(context, :unauthorized_msg, [resolution])})
+    Resolution.put_result(resolution, {:error, Rajska.apply_auth_mod(context, :unauthorized_message, [resolution])})
   end
 end

--- a/lib/middlewares/query_authorization.ex
+++ b/lib/middlewares/query_authorization.ex
@@ -44,7 +44,7 @@ defmodule Rajska.QueryAuthorization do
     validate_permission!(context, permission)
 
     context
-    |> Rajska.apply_auth_mod(:context_authorized?, [context, permission])
+    |> Rajska.apply_auth_mod(:context_role_authorized?, [context, permission])
     |> update_result(resolution)
     |> QueryScopeAuthorization.call(config)
   end

--- a/lib/middlewares/query_scope_authorization.ex
+++ b/lib/middlewares/query_scope_authorization.ex
@@ -116,7 +116,7 @@ defmodule Rajska.QueryScopeAuthorization do
   defp has_user_access?(scoped_struct_fields, scope, context, rule, _optional) do
     scoped_struct = scope.__struct__(scoped_struct_fields)
 
-    Rajska.apply_auth_mod(context, :has_user_access?, [context.current_user, scoped_struct, rule])
+    Rajska.apply_auth_mod(context, :context_user_authorized?, [context, scoped_struct, rule])
   end
 
   defp update_result(true, resolution), do: resolution

--- a/lib/middlewares/query_scope_authorization.ex
+++ b/lib/middlewares/query_scope_authorization.ex
@@ -85,7 +85,7 @@ defmodule Rajska.QueryScopeAuthorization do
 
     arg_fields
     |> Enum.map(& get_scoped_struct_field(arguments_source, &1, optional, resolution.definition.name))
-    |> Enum.filter(& !!&1)
+    |> Enum.reject(&is_nil/1)
     |> has_user_access?(scope, resolution.context, rule, optional)
     |> update_result(resolution)
   end

--- a/lib/middlewares/query_scope_authorization.ex
+++ b/lib/middlewares/query_scope_authorization.ex
@@ -43,14 +43,14 @@ defmodule Rajska.QueryScopeAuthorization do
 
   ## Options
 
-  All the following options are sent to `c:Rajska.Authorization.has_user_access?/4`:
+  All the following options are sent to `c:Rajska.Authorization.has_user_access?/3`:
 
     * `:scope`
       - `false`: disables scoping
-      - `User`: a module that will be passed to `c:Rajska.Authorization.has_user_access?/4`. It must define a struct.
+      - `User`: a module that will be passed to `c:Rajska.Authorization.has_user_access?/3`. It must define a struct.
     * `:args`
       - `%{user_id: [:params, :id]}`: where `user_id` is the scoped field and `id` is an argument nested inside the `params` argument.
-      - `:id`: this is the same as `%{id: :id}`, where `:id` is both the query argument and the scoped field that will be passed to `c:Rajska.Authorization.has_user_access?/4`
+      - `:id`: this is the same as `%{id: :id}`, where `:id` is both the query argument and the scoped field that will be passed to `c:Rajska.Authorization.has_user_access?/3`
       - `[:code, :user_group_id]`: this is the same as `%{code: :code, user_group_id: :user_group_id}`, where `code` and `user_group_id` are both query arguments and scoped fields.
     * `:optional` (optional) - when set to true the arguments are optional, so if no argument is provided, the query will be authorized. Defaults to false.
     * `:rule` (optional) - allows the same struct to have different rules. See `Rajska.Authorization` for `rule` default settings.

--- a/lib/rajska.ex
+++ b/lib/rajska.ex
@@ -23,7 +23,7 @@ defmodule Rajska do
 
   ## Usage
 
-  Create your Authorization module, which will implement the `Rajska.Authorization` behaviour and contain the logic to validate user permissions and will be called by Rajska middlewares. Rajska provides some helper functions by default, such as `c:Rajska.Authorization.role_authorized?/2`, `c:Rajska.Authorization.has_user_access?/4` and `c:Rajska.Authorization.field_authorized?/3`, but you can override them with your application needs.
+  Create your Authorization module, which will implement the `Rajska.Authorization` behaviour and contain the logic to validate user permissions and will be called by Rajska middlewares. Rajska provides some helper functions by default, such as `c:Rajska.Authorization.role_authorized?/2`, `c:Rajska.Authorization.has_user_access?/3` and `c:Rajska.Authorization.field_authorized?/3`, but you can override them with your application needs.
 
   ```elixir
   defmodule Authorization do
@@ -100,12 +100,9 @@ defmodule Rajska do
       def role_authorized?(user_role, allowed_role) when is_atom(allowed_role), do: user_role === allowed_role
       def role_authorized?(user_role, allowed_roles) when is_list(allowed_roles), do: user_role in allowed_roles
 
-      def has_user_access?(%user_struct{id: user_id} = current_user, scope, {field, field_value}, unquote(default_rule)) do
+      def has_user_access?(%user_struct{id: user_id} = current_user, %scope{} = struct, unquote(default_rule)) do
         super_user? = current_user |> get_user_role() |> super_role?()
-        owner? =
-          (user_struct === scope)
-          && (field === :id)
-          && (user_id === field_value)
+        owner? = (user_struct === scope) && (user_id === struct.id)
 
         super_user? || owner?
       end
@@ -129,7 +126,7 @@ defmodule Rajska do
       def has_context_access?(context, scope, {scope_field, field_value}, rule) do
         context
         |> get_current_user()
-        |> has_user_access?(scope, {scope_field, field_value}, rule)
+        |> has_user_access?(scope.__struct__([{scope_field, field_value}]), rule)
       end
 
       defoverridable Authorization

--- a/lib/rajska.ex
+++ b/lib/rajska.ex
@@ -16,7 +16,7 @@ defmodule Rajska do
   ```elixir
   def deps do
     [
-      {:rajska, "~> 0.8.1"},
+      {:rajska, "~> 0.9.0"},
     ]
   end
   ```

--- a/lib/rajska.ex
+++ b/lib/rajska.ex
@@ -116,17 +116,17 @@ defmodule Rajska do
         |> super_role?()
       end
 
-      def context_authorized?(context, allowed_role) do
+      def context_role_authorized?(context, allowed_role) do
         context
         |> get_current_user()
         |> get_user_role()
         |> role_authorized?(allowed_role)
       end
 
-      def has_context_access?(context, scope, {scope_field, field_value}, rule) do
+      def context_user_authorized?(context, scoped_struct, rule) do
         context
         |> get_current_user()
-        |> has_user_access?(scope.__struct__([{scope_field, field_value}]), rule)
+        |> has_user_access?(scoped_struct, rule)
       end
 
       defoverridable Authorization

--- a/lib/rajska.ex
+++ b/lib/rajska.ex
@@ -107,7 +107,7 @@ defmodule Rajska do
         super_user? || owner?
       end
 
-      def unauthorized_msg(_resolution), do: "unauthorized"
+      def unauthorized_message(_resolution), do: "unauthorized"
 
       def super_user?(context) do
         context

--- a/lib/rajska.ex
+++ b/lib/rajska.ex
@@ -23,7 +23,7 @@ defmodule Rajska do
 
   ## Usage
 
-  Create your Authorization module, which will implement the `Rajska.Authorization` behaviour and contain the logic to validate user permissions and will be called by Rajska middlewares. Rajska provides some helper functions by default, such as `c:Rajska.Authorization.role_authorized?/2`, `c:Rajska.Authorization.has_user_access?/3` and `c:Rajska.Authorization.field_authorized?/3`, but you can override them with your application needs.
+  Create your Authorization module, which will implement the `Rajska.Authorization` behaviour and contain the logic to validate user permissions and will be called by Rajska middlewares. Rajska provides some helper functions by default, such as `c:Rajska.Authorization.role_authorized?/2` and `c:Rajska.Authorization.has_user_access?/3`, but you can override them with your application needs.
 
   ```elixir
   defmodule Authorization do

--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -3,11 +3,8 @@ defmodule Rajska.Schema do
   Concatenates Rajska middlewares with Absinthe middlewares and validates Query Authorization configuration.
   """
 
-  alias Absinthe.Type.{
-    Field,
-    Middleware,
-    Object
-  }
+  alias Absinthe.Middleware
+  alias Absinthe.Type.{Field, Object}
 
   alias Rajska.{
     FieldAuthorization,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Rajska.MixProject do
   def project do
     [
       app: :rajska,
-      version: "0.8.1",
+      version: "0.9.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -13,12 +13,14 @@ defmodule Rajska.MixProject do
       description: "Rajska is an authorization library for Absinthe.",
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
+      aliases: aliases(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
         coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
-        "coveralls.html": :test
+        "coveralls.html": :test,
+        "test.all": :test
       ]
     ]
   end
@@ -49,6 +51,15 @@ defmodule Rajska.MixProject do
       {:credo, "~> 1.1.0", only: [:dev, :test], runtime: false},
       {:absinthe, "~> 1.4.0"},
       {:excoveralls, "~> 0.11", only: :test},
+    ]
+  end
+
+  defp aliases do
+    [
+      "test.all": [
+        "credo --strict",
+        "test"
+      ]
     ]
   end
 end

--- a/test/middlewares/field_authorization_test.exs
+++ b/test/middlewares/field_authorization_test.exs
@@ -157,7 +157,7 @@ defmodule Rajska.FieldAuthorizationTest do
     assert is_binary(data["phone"])
   end
 
-  test "Works when defining scope_field_by" do
+  test "Works when defining scope_field?" do
     user = %{role: :user, id: 1}
     get_user_query = get_field_scope_user(2)
 

--- a/test/middlewares/field_authorization_test.exs
+++ b/test/middlewares/field_authorization_test.exs
@@ -17,10 +17,10 @@ defmodule Rajska.FieldAuthorizationTest do
       valid_roles: [:user, :admin],
       super_role: :admin
 
-    def has_user_access?(_current_user, User, _field, :private), do: false
-    def has_user_access?(%{role: :admin}, User, _field, :default), do: true
-    def has_user_access?(%{id: user_id}, User, {:id, id}, :default) when user_id === id, do: true
-    def has_user_access?(_current_user, User, _field, :default), do: false
+    def has_user_access?(_current_user, %User{}, :private), do: false
+    def has_user_access?(%{role: :admin}, %User{}, :default), do: true
+    def has_user_access?(%{id: user_id}, %User{id: id}, :default) when user_id === id, do: true
+    def has_user_access?(_current_user, %User{}, :default), do: false
   end
 
   defmodule Schema do

--- a/test/middlewares/object_authorization_test.exs
+++ b/test/middlewares/object_authorization_test.exs
@@ -43,6 +43,13 @@ defmodule Rajska.ObjectAuthorizationTest do
           }}
         end
       end
+
+      field :enum_query, :role_enum do
+        middleware Rajska.QueryAuthorization, [permit: :all, scope: false]
+        resolve fn _, _ ->
+          {:ok, :user}
+        end
+      end
     end
 
     object :wallet_balance do
@@ -57,6 +64,11 @@ defmodule Rajska.ObjectAuthorizationTest do
       field :name, :string
 
       field :wallet_balance, :wallet_balance
+    end
+
+    enum :role_enum do
+      value :user
+      value :admin
     end
 
     object :user do
@@ -133,6 +145,13 @@ defmodule Rajska.ObjectAuthorizationTest do
     refute Map.has_key?(result, :errors)
   end
 
+  test "Query that returns an enum doesn't return errors" do
+    {:ok, result} = Absinthe.run(enum_query(), __MODULE__.Schema, context: %{current_user: %{role: :admin}})
+
+    assert %{data: %{"enumQuery" => "USER"}} = result
+    refute Map.has_key?(result, :errors)
+  end
+
   defp all_query do
     """
     {
@@ -184,4 +203,6 @@ defmodule Rajska.ObjectAuthorizationTest do
     }
     """
   end
+
+  defp enum_query, do:  "{ enumQuery }"
 end

--- a/test/middlewares/object_scope_authorization_test.exs
+++ b/test/middlewares/object_scope_authorization_test.exs
@@ -5,6 +5,7 @@ defmodule Rajska.ObjectScopeAuthorizationTest do
     defstruct [
       id: 1,
       total: 10,
+      user_id: nil
     ]
   end
 
@@ -39,18 +40,18 @@ defmodule Rajska.ObjectScopeAuthorizationTest do
       valid_roles: [:user, :admin],
       super_role: :admin
 
-    def has_user_access?(%{role: :admin}, User, _field, :default), do: true
-    def has_user_access?(%{id: user_id}, User, {:id, id}, :default) when user_id === id, do: true
-    def has_user_access?(_current_user, User, _field, :default), do: false
-    def has_user_access?(_current_user, User, _field, :object), do: false
+    def has_user_access?(%{role: :admin}, %User{}, :default), do: true
+    def has_user_access?(%{id: user_id}, %User{id: id}, :default) when user_id === id, do: true
+    def has_user_access?(_current_user, %User{}, :default), do: false
+    def has_user_access?(_current_user, %User{}, :object), do: false
 
-    def has_user_access?(%{role: :admin}, Company, _field, :default), do: true
-    def has_user_access?(%{id: user_id}, Company, {:user_id, company_user_id}, :default) when user_id === company_user_id, do: true
-    def has_user_access?(_current_user, Company, _field, :default), do: false
+    def has_user_access?(%{role: :admin}, %Company{}, :default), do: true
+    def has_user_access?(%{id: user_id}, %Company{user_id: company_user_id}, :default) when user_id === company_user_id, do: true
+    def has_user_access?(_current_user, %Company{}, :default), do: false
 
-    def has_user_access?(%{role: :admin}, Wallet, _field, :default), do: true
-    def has_user_access?(%{id: user_id}, Wallet, {:user_id, id}, :default) when user_id === id, do: true
-    def has_user_access?(_current_user, Wallet, _field, :default), do: false
+    def has_user_access?(%{role: :admin}, %Wallet{}, :default), do: true
+    def has_user_access?(%{id: user_id}, %Wallet{user_id: id}, :default) when user_id === id, do: true
+    def has_user_access?(_current_user, %Wallet{}, :default), do: false
   end
 
   defmodule Schema do

--- a/test/middlewares/query_scope_authorization_test.exs
+++ b/test/middlewares/query_scope_authorization_test.exs
@@ -21,12 +21,12 @@ defmodule Rajska.QueryScopeAuthorizationTest do
       valid_roles: [:user, :admin],
       super_role: :admin
 
-    def has_user_access?(%{role: :admin}, User, _field, :default), do: true
-    def has_user_access?(%{id: user_id}, User, {:id, id}, :default) when user_id === id, do: true
-    def has_user_access?(_current_user, User, _field, :default), do: false
+    def has_user_access?(%{role: :admin}, %User{}, :default), do: true
+    def has_user_access?(%{id: user_id}, %User{id: id}, :default) when user_id === id, do: true
+    def has_user_access?(_current_user, %User{}, :default), do: false
 
-    def has_user_access?(_current_user, BankAccount, _field, :edit), do: false
-    def has_user_access?(_current_user, BankAccount, _field, :read_only), do: true
+    def has_user_access?(_current_user, %BankAccount{}, :edit), do: false
+    def has_user_access?(_current_user, %BankAccount{}, :read_only), do: true
   end
 
   defmodule Schema do


### PR DESCRIPTION
Closes #19

Current callback: 

```elixir
@callback has_user_access?(
    current_user,
    scope :: module(),
    {field :: any(), field_value :: any()},
    rule :: any()
  ) :: boolean()
```

- [x]  Merge `scope` module and `{field, field_value}` arguments into a struct, since scope module must define a `struct`
- [x]  Pass entire objects from field and query scope authorization to new `has_user_access?/3`
- [x]  Rename `scope_by`, `scope_object_by` and `scope_field_by` metas to `scope?`, `scope_object?` and `scope_field?`
- [x]  Set default `scope?` value to true