### PR TITLE
Support functions in query scope authorization args

### DIFF
--- a/lib/middlewares/query_scope_authorization.ex
+++ b/lib/middlewares/query_scope_authorization.ex
@@ -61,6 +61,9 @@ defmodule Rajska.QueryScopeAuthorization do
       - `User`: a module that will be passed to `c:Rajska.Authorization.has_user_access?/3`. It must define a struct.
     * `:args`
       - `%{user_id: [:params, :id]}`: where `user_id` is the scoped field and `id` is an argument nested inside the `params` argument.
+      This form also accepts a function in the array (the same way as described in the [Kernel.get_in/2](https://hexdocs.pm/elixir/Kernel.html#get_in/2-functions-as-keys)).
+      This way, we can also use `%{user_id: [:params, Access.all(), :id]}` and for an input arg like `params: [%{id: 1}, %{id: 2}]`,
+      the builded struct will have the value `%User{user_id: [1, 2]}`.
       - `:id`: this is the same as `%{id: :id}`, where `:id` is both the query argument and the scoped field that will be passed to `c:Rajska.Authorization.has_user_access?/3`
       - `[:code, :user_group_id]`: this is the same as `%{code: :code, user_group_id: :user_group_id}`, where `code` and `user_group_id` are both query arguments and scoped fields.
     * `:optional` (optional) - when set to true the arguments are optional, so if no argument is provided, the query will be authorized. Defaults to false.

--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -128,21 +128,26 @@ defmodule Rajska.Schema do
   defp validate_args!(args) when is_map(args) do
     Enum.each(args, fn
       {field, value} when is_atom(field) and is_atom(value) -> :ok
-      {field, values} when is_atom(field) and is_list(values)  -> validate_list_of_atoms!(values)
+      {field, values} when is_atom(field) and is_list(values) -> validate_list_of_atoms_or_function!(values)
       field_value -> raise "the following args option is invalid: #{inspect(field_value)}. Since the provided args is a map, you should provide an atom key and an atom or list of atoms value."
     end)
   end
 
   defp validate_args!(args) when is_list(args), do: validate_list_of_atoms!(args)
-
   defp validate_args!(args) when is_atom(args), do: :ok
-
   defp validate_args!(args), do: raise "the following args option is invalid: #{inspect(args)}"
 
   defp validate_list_of_atoms!(args) do
     Enum.each(args, fn
       arg when is_atom(arg) -> :ok
       arg -> raise "the following args option is invalid: #{inspect(args)}. Expected a list of atoms, but found #{inspect(arg)}"
+    end)
+  end
+
+  defp validate_list_of_atoms_or_function!(args) do
+    Enum.each(args, fn
+      arg when is_atom(arg) or is_function(arg) -> :ok
+      arg -> raise "the following args option is invalid: #{inspect(args)}. Expected a list of atoms or functions, but found #{inspect(arg)}"
     end)
   end
 end


### PR DESCRIPTION
This PR allow us to use access functions in the `args` option of `Rajska.QueryAuthorization` (like explained in elixir docs https://hexdocs.pm/elixir/Kernel.html#get_in/2-functions-as-keys)

Example:

```elixir
input_object :create_user_param do
  field :email, non_null(:string)
end

field :create_users, list_of(:user) do
  arg :params, list_of(:example_params)

  middleware Rajska.QueryAuthorization, [
    permit: :user,
    scope: User,
    args: %{email: [:params, Access.all(), :email]},
  ]
  resolve &AccountsResolver.create_users/2
end
```